### PR TITLE
AD-HOC feat (Meta): Add a meta/main.yaml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,13 @@
+galaxy_info:
+  author: Sitewards
+  description: Install the Prometheus node exporter
+  company: Sitewards
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 2.4
+
+  galaxy_tags:
+    - Prometheus
+    - Node Exporter
+
+dependencies: []


### PR DESCRIPTION
Ansible galaxy will not function as expected unless there is a role
declaration at the "meta/main.yaml" path. This commit creates such a
declaration.