### PR TITLE
AD-HOC fix (metrics): Add dir that allows metric storage

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,0 +1,6 @@
+---
+- name: "Create the textfile metrics directory"
+  file:
+    path: "{{ node_exporter_textfile_directory }}"
+    state: "directory"
+    mode: "u=rwx,g=rwx,o=rwx"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
+- include: "configuration.yml"
 - include: "binary.yml"
 - include: "systemd.yml"


### PR DESCRIPTION
This role was initially written in conjunction with another
instrumentation role, which handled the creation of the dir. That role
is now removed, and this role now fails.

This commit adds the dir for storing metrics in a dir.