### PR TITLE
AD-HOC fix (metrics): service autostart

### DIFF
--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -6,3 +6,9 @@
     owner: "root"
     mode: "u=rwx,g=r,o=r"
   notify: "restart node_exporter"
+
+- name: "Make sure node exporter service is running and auto-starting"
+  service:
+    name: "node_exporter"
+    state: "started"
+    enabled: "yes"


### PR DESCRIPTION
node exporter service was not enabled, i.e. it was not added to list of system
auto-starting services, that caused monitoring alert upon server reboot.