### PR TITLE
Update node_exporter.service.j2

### DIFF
--- a/templates/etc/systemd/system/node_exporter.service.j2
+++ b/templates/etc/systemd/system/node_exporter.service.j2
@@ -10,8 +10,7 @@ Restart=always
 # Start the service, bound to localhost. It will be exposed by another service, such as NGINX or stunnel.
 ExecStart=/usr/local/bin/node_exporter \
     --collector.textfile.directory="{{ node_exporter_textfile_directory }}" \
-    --web.listen-address="127.0.0.1:9100" \
-    --collectors.enabled="{{ node_exporter_exporters | join(',') }}"
+    --web.listen-address="127.0.0.1:9100"
 
 [Install]
 


### PR DESCRIPTION
 --collectors.enabled does not work with newer versions of node exporter. It must be substituted by other code construct.