### PR TITLE
[FIX] remove hardcoded version values

### DIFF
--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -24,7 +24,7 @@
 - name: "Move node-exporter to the /usr/local/bin/node-exporter"
   copy:
     remote_src: true
-    src: "/tmp/node_exporter-0.14.0.linux-{{ node_exporter_arch }}/node_exporter"
+    src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ node_exporter_arch }}/node_exporter"
     dest: "/usr/local/bin/node_exporter"
     owner: "root"
     group: "root"
@@ -39,6 +39,6 @@
     state: "absent"
   with_items:
     - "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ node_exporter_arch }}.tar.gz"
-    - "/tmp/node_exporter-0.14.0.linux-{{ node_exporter_arch }}/"
+    - "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ node_exporter_arch }}/"
   when: bin.stat.exists == False or
         bin.stat.checksum != node_exporter_checksum_binary


### PR DESCRIPTION
  The version of the node exporter is controlled using a variable - node_exporter_version
  unfortunatelly some of the tasks were not using the variable but instead having
  hardcoded version strings.

  This commit removes the hardcoded version strings to ensure changing the version using the variable
  works as expected